### PR TITLE
fix: 修正 macOS 下载页 Apple 芯片描述

### DIFF
--- a/src/i18n/lang/en.json
+++ b/src/i18n/lang/en.json
@@ -247,7 +247,7 @@
     "best_for_most": "Best for most computers",
     "no_install_needed": "No installation needed, portable",
     "for_arm_devices": "For ARM devices",
-    "apple_silicon": "Apple Silicon (M1/M2/M3/M4)",
+    "apple_silicon": "Apple Silicon (M Series)",
     "intel_mac": "Intel Chip",
     "universal_linux": "Universal Linux version",
     "for_debian_ubuntu": "For Debian/Ubuntu",

--- a/src/i18n/lang/zh.json
+++ b/src/i18n/lang/zh.json
@@ -245,7 +245,7 @@
     "best_for_most": "适合大多数电脑",
     "no_install_needed": "无需安装，解压即用",
     "for_arm_devices": "适用于 ARM 设备",
-    "apple_silicon": "Apple 芯片 (M1/M2/M3/M4)",
+    "apple_silicon": "Apple 芯片 (M 系列)",
     "intel_mac": "Intel 芯片",
     "universal_linux": "通用 Linux 版本",
     "for_debian_ubuntu": "适用于 Debian/Ubuntu",


### PR DESCRIPTION
原先的描述为"Apple 芯片 (M1/M2/M3/M4)"，漏了 M5，于是直接修改成 M系列 
<img width="1710" height="371" alt="image" src="https://github.com/user-attachments/assets/4f3a394b-be24-4b4c-9928-a765e8e61964" />
