### PR TITLE
feat: Add designer career position

### DIFF
--- a/src/i18n/lang/en.json
+++ b/src/i18n/lang/en.json
@@ -157,6 +157,10 @@
       "ai": {
         "title": "AI Application Engineer",
         "description": "Proficient with AI coding tools, familiar with RAG, LangChain frameworks"
+      },
+      "designer": {
+        "title": "AI Product Designer",
+        "description": "Own full-platform UI/UX and brand tone, building AI-native design systems"
       }
     },
     "location_title": "Location",

--- a/src/i18n/lang/zh.json
+++ b/src/i18n/lang/zh.json
@@ -155,6 +155,10 @@
       "ai": {
         "title": "AI 应用工程师",
         "description": "熟练使用 AI 编程工具，了解 RAG、LangChain 等框架"
+      },
+      "designer": {
+        "title": "AI 产品设计师",
+        "description": "负责全平台 UI/UX 与品牌调性，打造 AI-native 设计系统"
       }
     },
     "location_title": "工作地点",

--- a/src/pages/careers/index.tsx
+++ b/src/pages/careers/index.tsx
@@ -14,7 +14,8 @@ const CareersPage: FC = () => {
     { key: 'backend', icon: '⚙️' },
     { key: 'fullstack', icon: '🔧' },
     { key: 'mobile', icon: '📱' },
-    { key: 'ai', icon: '🤖' }
+    { key: 'ai', icon: '🤖' },
+    { key: 'designer', icon: '🎨' }
   ]
 
   const benefits = ['no_clock', 'equity', 'ai_native', 'growth']

--- a/src/pages/careers/index.tsx
+++ b/src/pages/careers/index.tsx
@@ -78,7 +78,7 @@ const CareersPage: FC = () => {
           <div className="mt-8 text-center">
             <Button variant="outline" asChild>
               <a
-                href="https://github.com/CherryHQ/cherry-studio/issues/11953"
+                href="https://applink.feishu.cn/client/message/link/open?token=AmmuYiarQIzWaiqbRiQAjLo%3D"
                 target="_blank"
                 rel="noopener noreferrer">
                 {t('careers.view_full_jd')}


### PR DESCRIPTION
## Summary
- Add an AI Product Designer opening to the careers page.
- Add matching Chinese and English i18n copy for the new position.

## Validation
- pnpm exec biome check src/pages/careers/index.tsx src/i18n/lang/en.json src/i18n/lang/zh.json
- pnpm build
- Verified /careers renders the new position locally.