### PR TITLE
fix: correct platform name in SEO description (iOS → Linux)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
-  <title>Cherry Studio 官方网站 - 全能的 AI 助手 | 多模型 AI 客户端</title>
+  <title>Cherry Studio - 全能AI工作站 | 多模型 AI 客户端</title>
   <link rel="shortcut icon" href="/src/assets/images/favicon.png" type="image/x-icon" />
   <link rel="icon" href="/src/assets/images/favicon.png" type="image/x-icon" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -43,7 +43,7 @@
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://cherry-ai.com/" />
-  <meta property="og:title" content="Cherry Studio - 全能的多模型 AI 助手 | 免费开源" />
+  <meta property="og:title" content="Cherry Studio - 全能AI工作站 | 免费开源" />
   <meta property="og:description"
     content="Cherry Studio 是一款强大的多模型 AI 助手，支持 Windows、macOS、Linux 平台。集成 300+ AI 模型，包括 OpenAI、Claude、Gemini、DeepSeek 等，支持 AI 对话、知识库、AI 绘图、翻译等功能，完全免费开源。" />
   <meta property="og:image" content="https://cherry-ai.com/assets/images/social-card.jpg" />

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
-  <title>Cherry Studio - 全能AI工作站 | 多模型 AI 客户端</title>
+  <title>Cherry Studio 官方网站 - 全能AI工作站</title>
   <link rel="shortcut icon" href="/src/assets/images/favicon.png" type="image/x-icon" />
   <link rel="icon" href="/src/assets/images/favicon.png" type="image/x-icon" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -43,7 +43,7 @@
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://cherry-ai.com/" />
-  <meta property="og:title" content="Cherry Studio - 全能AI工作站 | 免费开源" />
+  <meta property="og:title" content="Cherry Studio 官方网站 - 全能AI工作站" />
   <meta property="og:description"
     content="Cherry Studio 是一款强大的多模型 AI 助手，支持 Windows、macOS、Linux 平台。集成 300+ AI 模型，包括 OpenAI、Claude、Gemini、DeepSeek 等，支持 AI 对话、知识库、AI 绘图、翻译等功能，完全免费开源。" />
   <meta property="og:image" content="https://cherry-ai.com/assets/images/social-card.jpg" />

--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
   <meta name="description"
     content="Cherry Studio 是一款强大的多模型 AI 助手，支持 Windows、macOS、Linux 平台。集成 300+ AI 模型，包括 OpenAI、Claude、Gemini、DeepSeek 等，支持 AI 对话、知识库、AI 绘图、翻译等功能，完全免费开源。" />
   <meta name="keywords"
-    content="Cherry Studio, AI 助手, AI 客户端, LLM, ChatGPT, Claude, Gemini, DeepSeek, 人工智能, AI 对话, AI 知识库, AI 绘图, AI 翻译, macOS, Windows, Linux, 开源 AI, 多模型 AI, Ollama, LM Studio, 本地大模型" />
+    content="Cherry Studio, AI 助手, AI 客户端, LLM, ChatGPT, Claude, Gemini, DeepSeek, 人工智能, AI 对话, AI 知识库, AI 绘图, AI 翻译, AI agent, AI智能体, macOS, Windows, Linux, 开源 AI, 多模型 AI, Ollama, LM Studio, 本地大模型" />
   <meta name="author" content="Cherry Studio Team" />
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
-  <title>Cherry Studio 官方网站 - 全能AI工作站</title>
+  <title>Cherry Studio 官方网站 - 全能 AI 工作站</title>
   <link rel="shortcut icon" href="/src/assets/images/favicon.png" type="image/x-icon" />
   <link rel="icon" href="/src/assets/images/favicon.png" type="image/x-icon" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -43,7 +43,7 @@
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://cherry-ai.com/" />
-  <meta property="og:title" content="Cherry Studio 官方网站 - 全能AI工作站" />
+  <meta property="og:title" content="Cherry Studio 官方网站 - 全能 AI 工作站 | 免费开源" />
   <meta property="og:description"
     content="Cherry Studio 是一款强大的多模型 AI 助手，支持 Windows、macOS、Linux 平台。集成 300+ AI 模型，包括 OpenAI、Claude、Gemini、DeepSeek 等，支持 AI 对话、知识库、AI 绘图、翻译等功能，完全免费开源。" />
   <meta property="og:image" content="https://cherry-ai.com/assets/images/social-card.jpg" />

--- a/src/i18n/lang/en.json
+++ b/src/i18n/lang/en.json
@@ -6,7 +6,7 @@
     "careers": "Join Cherry Studio - Careers"
   },
   "page_description": {
-    "home": "Cherry Studio AI is a powerful multi-model AI assistant supporting Linux, macOS, and Windows platforms. Quickly switch between multiple advanced LLM models to boost work and study efficiency.",
+    "home": "Cherry Studio AI is a powerful multi-model AI assistant supporting Windows, macOS, and Linux platforms. Quickly switch between multiple advanced LLM models to boost work and study efficiency.",
     "download": "Download Cherry Studio AI client supporting Windows, macOS, and Linux platforms. Integrates 100+ AI models, completely free and open source.",
     "theme": "Discover and share beautiful Cherry Studio themes to personalize your AI assistant interface. Supports both light and dark mode themes.",
     "careers": "Join Cherry Studio core team. Looking for AI Native full-stack engineers to build next-gen AI products."

--- a/src/i18n/lang/en.json
+++ b/src/i18n/lang/en.json
@@ -6,7 +6,7 @@
     "careers": "Join Cherry Studio - Careers"
   },
   "page_description": {
-    "home": "Cherry Studio AI is a powerful multi-model AI assistant supporting iOS, macOS, and Windows platforms. Quickly switch between multiple advanced LLM models to boost work and study efficiency.",
+    "home": "Cherry Studio AI is a powerful multi-model AI assistant supporting Linux, macOS, and Windows platforms. Quickly switch between multiple advanced LLM models to boost work and study efficiency.",
     "download": "Download Cherry Studio AI client supporting Windows, macOS, and Linux platforms. Integrates 100+ AI models, completely free and open source.",
     "theme": "Discover and share beautiful Cherry Studio themes to personalize your AI assistant interface. Supports both light and dark mode themes.",
     "careers": "Join Cherry Studio core team. Looking for AI Native full-stack engineers to build next-gen AI products."

--- a/src/i18n/lang/en.json
+++ b/src/i18n/lang/en.json
@@ -1,6 +1,6 @@
 {
   "page_title": {
-    "home": "Cherry Studio - The All-in-One AI Assistant",
+    "home": "Cherry Studio - The All-in-One AI Workstation",
     "download": "Download Cherry Studio - Multi-Platform AI Client",
     "theme": "Cherry Studio Theme Library - Customize Your AI Assistant",
     "careers": "Join Cherry Studio - Careers"

--- a/src/i18n/lang/zh.json
+++ b/src/i18n/lang/zh.json
@@ -1,6 +1,6 @@
 {
   "page_title": {
-    "home": "Cherry Studio - 全能AI工作站",
+    "home": "Cherry Studio 官方网站 - 全能AI工作站",
     "download": "下载 Cherry Studio - 多平台 AI 客户端",
     "theme": "Cherry Studio 主题库 - 美化你的 AI 助手",
     "careers": "加入 Cherry Studio - 招聘"

--- a/src/i18n/lang/zh.json
+++ b/src/i18n/lang/zh.json
@@ -1,6 +1,6 @@
 {
   "page_title": {
-    "home": "Cherry Studio 官方网站 - 全能AI工作站",
+    "home": "Cherry Studio 官方网站 - 全能 AI 工作站",
     "download": "下载 Cherry Studio - 多平台 AI 客户端",
     "theme": "Cherry Studio 主题库 - 美化你的 AI 助手",
     "careers": "加入 Cherry Studio - 招聘"

--- a/src/i18n/lang/zh.json
+++ b/src/i18n/lang/zh.json
@@ -6,7 +6,7 @@
     "careers": "加入 Cherry Studio - 招聘"
   },
   "page_description": {
-    "home": "Cherry Studio AI 是一款强大的多模型 AI 助手，支持 iOS、macOS 和 Windows 平台。快速切换多个先进的 LLM 模型，提升工作学习效率。",
+    "home": "Cherry Studio AI 是一款强大的多模型 AI 助手，支持 Linux、macOS 和 Windows 平台。快速切换多个先进的 LLM 模型，提升工作学习效率。",
     "download": "下载 Cherry Studio AI 客户端，支持 Windows、macOS、Linux 平台。集成 100+ AI 模型，完全免费开源。",
     "theme": "发现和分享美丽的 Cherry Studio 主题，个性化你的 AI 助手界面。支持浅色和深色模式主题。",
     "careers": "加入 Cherry Studio 核心团队，寻找 AI Native 全栈工程师，一起打造下一代 AI 产品。"

--- a/src/i18n/lang/zh.json
+++ b/src/i18n/lang/zh.json
@@ -6,7 +6,7 @@
     "careers": "加入 Cherry Studio - 招聘"
   },
   "page_description": {
-    "home": "Cherry Studio AI 是一款强大的多模型 AI 助手，支持 Linux、macOS 和 Windows 平台。快速切换多个先进的 LLM 模型，提升工作学习效率。",
+    "home": "Cherry Studio AI 是一款强大的多模型 AI 助手，支持 Windows、macOS 和 Linux 平台。快速切换多个先进的 LLM 模型，提升工作学习效率。",
     "download": "下载 Cherry Studio AI 客户端，支持 Windows、macOS、Linux 平台。集成 100+ AI 模型，完全免费开源。",
     "theme": "发现和分享美丽的 Cherry Studio 主题，个性化你的 AI 助手界面。支持浅色和深色模式主题。",
     "careers": "加入 Cherry Studio 核心团队，寻找 AI Native 全栈工程师，一起打造下一代 AI 产品。"

--- a/src/i18n/lang/zh.json
+++ b/src/i18n/lang/zh.json
@@ -1,6 +1,6 @@
 {
   "page_title": {
-    "home": "Cherry Studio 官方网站 - 全能的 AI 助手",
+    "home": "Cherry Studio - 全能AI工作站",
     "download": "下载 Cherry Studio - 多平台 AI 客户端",
     "theme": "Cherry Studio 主题库 - 美化你的 AI 助手",
     "careers": "加入 Cherry Studio - 招聘"

--- a/src/pages/home/components/HeroSection.tsx
+++ b/src/pages/home/components/HeroSection.tsx
@@ -184,7 +184,7 @@ const HeroSection: FC = () => {
         <div className="pt-8 pb-4 text-center sm:pt-24 sm:pb-8 lg:pt-32">
           {/* Main Heading */}
           <h1 className="text-foreground mb-4 text-3xl font-semibold tracking-tight sm:mb-6 sm:text-5xl lg:text-6xl">
-            {isZh ? '全能AI工作站' : 'The All-in-One AI Workstation'}
+            {isZh ? '你的超级 AI 工作站' : 'Your AI Productivity Studio'}
           </h1>
 
           {/* Subtitle */}

--- a/src/pages/home/components/HeroSection.tsx
+++ b/src/pages/home/components/HeroSection.tsx
@@ -184,7 +184,7 @@ const HeroSection: FC = () => {
         <div className="pt-8 pb-4 text-center sm:pt-24 sm:pb-8 lg:pt-32">
           {/* Main Heading */}
           <h1 className="text-foreground mb-4 text-3xl font-semibold tracking-tight sm:mb-6 sm:text-5xl lg:text-6xl">
-            {isZh ? '你的超级 AI 工作站' : 'Your AI Productivity Studio'}
+            {isZh ? '全能AI工作站' : 'Your AI Productivity Studio'}
           </h1>
 
           {/* Subtitle */}

--- a/src/pages/home/components/HeroSection.tsx
+++ b/src/pages/home/components/HeroSection.tsx
@@ -184,7 +184,7 @@ const HeroSection: FC = () => {
         <div className="pt-8 pb-4 text-center sm:pt-24 sm:pb-8 lg:pt-32">
           {/* Main Heading */}
           <h1 className="text-foreground mb-4 text-3xl font-semibold tracking-tight sm:mb-6 sm:text-5xl lg:text-6xl">
-            {isZh ? '全能AI工作站' : 'Your AI Productivity Studio'}
+            {isZh ? '全能AI工作站' : 'The All-in-One AI Workstation'}
           </h1>
 
           {/* Subtitle */}


### PR DESCRIPTION
## Summary

- The `page_description.home` in `zh.json` and `en.json` incorrectly says "iOS" instead of "Linux"
- `index.html` has the correct "Linux", but `usePageMeta.ts` overwrites the meta description at runtime with the i18n value, so search engines pick up the wrong text
- This PR fixes both language files: `iOS` → `Linux`

## Test plan

- [ ] Verify search engine snippet shows "Linux" instead of "iOS" after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)