### PR TITLE
fix(seo): support regional static metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,12 +47,13 @@ All routes are defined in [src/App.tsx](src/App.tsx) with a shared header and Th
 
 ### Internationalization (i18n)
 
-The project uses i18next with browser language detection:
+The project uses i18next with domain-based language selection:
 
 - Configuration: [src/i18n/index.ts](src/i18n/index.ts)
 - Supported languages: `en-US`, `zh-CN`
 - Translation files: [src/i18n/lang/en.json](src/i18n/lang/en.json), [src/i18n/lang/zh.json](src/i18n/lang/zh.json)
-- Language preference stored in localStorage with key `i18n-language`
+- Production domains are fixed: `cherryai.com.cn` uses `zh-CN`, `cherryai.com` uses `en-US`
+- Local and non-fixed-domain language is controlled with `VITE_SITE_LOCALE=zh|en`
 - Automatically updates `<html lang>` attribute on language change
 
 When adding new translatable strings, add them to both language files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,12 +47,13 @@ All routes are defined in [src/App.tsx](src/App.tsx) with a shared header and Th
 
 ### Internationalization (i18n)
 
-The project uses i18next with browser language detection:
+The project uses i18next with domain-based language selection:
 
 - Configuration: [src/i18n/index.ts](src/i18n/index.ts)
 - Supported languages: `en-US`, `zh-CN`
 - Translation files: [src/i18n/lang/en.json](src/i18n/lang/en.json), [src/i18n/lang/zh.json](src/i18n/lang/zh.json)
-- Language preference stored in localStorage with key `i18n-language`
+- Production domains are fixed: `cherryai.com.cn` uses `zh-CN`, `cherryai.com` uses `en-US`
+- Local and non-fixed-domain language is controlled with `VITE_SITE_LOCALE=zh|en`
 - Automatically updates `<html lang>` attribute on language change
 
 When adding new translatable strings, add them to both language files.

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN pnpm install --frozen-lockfile
 # Copy source code
 COPY . .
 
-# Build the application
-RUN pnpm build
+# Build the Chinese mainland deployment
+RUN pnpm build:cn
 
 ARG MIRROR
 

--- a/index.html
+++ b/index.html
@@ -27,16 +27,16 @@
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <!-- 规范链接和多语言 -->
-  <link rel="canonical" href="https://cherry-ai.com/" />
-  <link rel="alternate" hreflang="zh-CN" href="https://cherry-ai.com/" />
-  <link rel="alternate" hreflang="en" href="https://cherry-ai.com/" />
-  <link rel="alternate" hreflang="x-default" href="https://cherry-ai.com/" />
+  <link rel="canonical" href="https://cherryai.com.cn/" />
+  <link rel="alternate" hreflang="zh-CN" href="https://cherryai.com.cn/" />
+  <link rel="alternate" hreflang="en" href="https://cherryai.com/" />
+  <link rel="alternate" hreflang="x-default" href="https://cherryai.com.cn/" />
   <!-- Robots -->
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
   <meta name="googlebot" content="index, follow" />
   <!-- SEO 基础信息 -->
   <meta name="description"
-    content="Cherry Studio 是一款强大的多模型 AI 助手，支持 Windows、macOS、Linux 平台。集成 300+ AI 模型，包括 OpenAI、Claude、Gemini、DeepSeek 等，支持 AI 对话、知识库、AI 绘图、翻译等功能，完全免费开源。" />
+    content="Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选" />
   <meta name="keywords"
     content="Cherry Studio, AI 助手, AI 客户端, LLM, ChatGPT, Claude, Gemini, DeepSeek, 人工智能, AI 对话, AI 知识库, AI 绘图, AI 翻译, AI agent, AI智能体, macOS, Windows, Linux, 开源 AI, 多模型 AI, Ollama, LM Studio, 本地大模型" />
   <meta name="author" content="Cherry Studio Team" />
@@ -45,7 +45,7 @@
   <meta property="og:url" content="https://cherry-ai.com/" />
   <meta property="og:title" content="Cherry Studio 官方网站 - 全能 AI 工作站 | 免费开源" />
   <meta property="og:description"
-    content="Cherry Studio 是一款强大的多模型 AI 助手，支持 Windows、macOS、Linux 平台。集成 300+ AI 模型，包括 OpenAI、Claude、Gemini、DeepSeek 等，支持 AI 对话、知识库、AI 绘图、翻译等功能，完全免费开源。" />
+    content="Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选" />
   <meta property="og:image" content="https://cherry-ai.com/assets/images/social-card.jpg" />
   <meta property="og:site_name" content="Cherry Studio" />
   <meta property="og:locale" content="zh_CN" />
@@ -60,19 +60,20 @@
   <meta name="twitter:creator" content="@CherryStudioAI" />
   <meta name="twitter:title" content="Cherry Studio - 全能的多模型 AI 助手" />
   <meta name="twitter:description"
-    content="集成 300+ AI 模型的桌面客户端，支持 OpenAI、Claude、Gemini、DeepSeek。AI 对话、知识库、绘图、翻译，完全免费开源。" />
+    content="Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选" />
   <meta name="twitter:image" content="https://cherry-ai.com/assets/images/social-card.jpg" />
   <meta name="twitter:image:alt" content="Cherry Studio - 多模型 AI 助手桌面客户端" />
   <meta name="twitter:domain" content="cherry-ai.com" />
   <!-- 微信分享 -->
   <meta itemprop="name" content="Cherry Studio - 全能的多模型 AI 助手" />
   <meta itemprop="description"
-    content="Cherry Studio 是一款强大的多模型 AI 助手，支持 Windows、macOS、Linux 平台。集成 300+ AI 模型，完全免费开源。" />
+    content="Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选" />
   <meta itemprop="image" content="https://cherry-ai.com/assets/images/social-card.jpg" />
   <!-- QQ 分享 -->
   <meta name="qq:card" content="article" />
   <meta name="qq:title" content="Cherry Studio - 全能的多模型 AI 助手" />
-  <meta name="qq:description" content="Cherry Studio 是一款强大的多模型 AI 助手，支持 Windows、macOS、Linux 平台。集成 300+ AI 模型，完全免费开源。" />
+  <meta name="qq:description"
+    content="Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选" />
   <meta name="qq:image" content="https://cherry-ai.com/assets/images/social-card.jpg" />
   <!-- RSS Feed -->
   <link rel="alternate" type="application/rss+xml" title="Cherry Studio 更新日志" href="https://cherry-rss.ocool.online/" />
@@ -85,7 +86,7 @@
     "alternateName": "CherryHQ",
     "url": "https://cherry-ai.com",
     "logo": "https://cherry-ai.com/assets/images/favicon.png",
-    "description": "Cherry Studio 是一款强大的多模型 AI 助手，支持 Windows、macOS、Linux 平台",
+    "description": "Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选",
     "sameAs": [
       "https://github.com/CherryHQ/cherry-studio",
       "https://gitcode.com/CherryHQ/cherry-studio",
@@ -111,7 +112,7 @@
       "price": "0",
       "priceCurrency": "USD"
     },
-    "description": "Cherry Studio 是一款集成 300+ AI 模型的多平台桌面客户端，支持 OpenAI、Claude、Gemini、DeepSeek 等主流模型，提供 AI 对话、知识库、AI 绘图、翻译等功能，完全免费开源。",
+    "description": "Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选",
     "downloadUrl": "https://cherry-ai.com/download",
     "softwareVersion": "latest",
     "author": {
@@ -142,7 +143,7 @@
     "name": "Cherry Studio",
     "alternateName": "Cherry Studio 官方网站",
     "url": "https://cherry-ai.com",
-    "description": "Cherry Studio 官方网站 - 下载全能的多模型 AI 助手",
+    "description": "Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选",
     "inLanguage": ["zh-CN", "en"],
     "publisher": {
       "@type": "Organization",
@@ -186,6 +187,16 @@
   </script>
   <script src="https://udify.app/embed.min.js" id="PibHm0oSaN8nxqe3" defer>
   </script>
+  <script>
+    var _hmt = _hmt || [];
+    (function () {
+      var hm = document.createElement("script");
+      hm.src = "https://hm.baidu.com/hm.js?449345f4fcbd338fc35a4ca7c70922d4";
+      var s = document.getElementsByTagName("script")[0];
+      s.parentNode.insertBefore(hm, s);
+    })();
+  </script>
+
 </body>
 
 </html>

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "pnpm build:en",
+    "build:cn": "tsc -b && vite build && SITE_LOCALE=zh node scripts/finalize-static-site.mjs",
+    "build:en": "tsc -b && vite build && SITE_LOCALE=en node scripts/finalize-static-site.mjs",
     "format": "biome format --write .",
     "lint": "biome lint --write .",
     "check": "biome check --write .",
     "preview": "vite preview",
-    "release": "pnpm build && rsync -rvztl --delete ./dist/* tencent.vm:/opt/1panel/apps/openresty/openresty/www/sites/cherry-ai.com/index"
+    "release": "pnpm build:cn && rsync -rvztl --delete ./dist/* tencent.vm:/opt/1panel/apps/openresty/openresty/www/sites/cherry-ai.com/index"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "pnpm build:en",
-    "build:cn": "tsc -b && vite build && SITE_LOCALE=zh node scripts/finalize-static-site.mjs",
-    "build:en": "tsc -b && vite build && SITE_LOCALE=en node scripts/finalize-static-site.mjs",
+    "build:cn": "tsc -b && VITE_SITE_LOCALE=zh vite build && SITE_LOCALE=zh node scripts/finalize-static-site.mjs",
+    "build:en": "tsc -b && VITE_SITE_LOCALE=en vite build && SITE_LOCALE=en node scripts/finalize-static-site.mjs",
     "format": "biome format --write .",
     "lint": "biome lint --write .",
     "check": "biome check --write .",
@@ -26,7 +26,6 @@
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.24",
     "i18next": "^25.2.1",
-    "i18next-browser-languagedetector": "^8.2.0",
     "lucide-react": "^0.546.0",
     "marked": "^17.0.1",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       i18next:
         specifier: ^25.2.1
         version: 25.2.1(typescript@5.6.3)
-      i18next-browser-languagedetector:
-        specifier: ^8.2.0
-        version: 8.2.0
       lucide-react:
         specifier: ^0.546.0
         version: 0.546.0(react@18.3.1)
@@ -1584,9 +1581,6 @@ packages:
 
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
-
-  i18next-browser-languagedetector@8.2.0:
-    resolution: {integrity: sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==}
 
   i18next@25.2.1:
     resolution: {integrity: sha512-+UoXK5wh+VlE1Zy5p6MjcvctHXAhRwQKCxiJD8noKZzIXmnAX8gdHX5fLPA3MEVxEN4vbZkQFy8N0LyD9tUqPw==}
@@ -3661,10 +3655,6 @@ snapshots:
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
-
-  i18next-browser-languagedetector@8.2.0:
-    dependencies:
-      '@babel/runtime': 7.27.6
 
   i18next@25.2.1(typescript@5.6.3):
     dependencies:

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://cherryai.com.cn/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://cherryai.com.cn/</loc>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://cherryai.com.cn/download</loc>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://docs.cherry-ai.com/</loc>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://enterprise.cherryai.com.cn/</loc>
+    <priority>0.7</priority>
+  </url>
+</urlset>

--- a/scripts/finalize-static-site.mjs
+++ b/scripts/finalize-static-site.mjs
@@ -1,0 +1,214 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const distDir = join(process.cwd(), 'dist')
+const target = process.env.SITE_LOCALE || process.argv[2] || 'zh'
+
+const configs = {
+  zh: {
+    lang: 'zh-CN',
+    domain: 'https://cherryai.com.cn',
+    title: 'Cherry Studio 官方网站 - 全能 AI 工作站',
+    ogTitle: 'Cherry Studio 官方网站 - 全能 AI 工作站 | 免费开源',
+    shareTitle: 'Cherry Studio - 全能的多模型 AI 助手',
+    description:
+      'Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选',
+    keywords:
+      'Cherry Studio, AI 助手, AI 客户端, LLM, ChatGPT, Claude, Gemini, DeepSeek, 人工智能, AI 对话, AI 知识库, AI 绘图, AI 翻译, AI agent, AI智能体, macOS, Windows, Linux, 开源 AI, 多模型 AI, Ollama, LM Studio, 本地大模型',
+    ogLocale: 'zh_CN',
+    ogLocaleAlternate: 'en_US',
+    imageAlt: 'Cherry Studio - 多模型 AI 助手桌面客户端',
+    rssTitle: 'Cherry Studio 更新日志',
+    websiteAlternateName: 'Cherry Studio 官方网站',
+    publisherName: '上海千彗科技有限公司',
+    baiduAnalytics: true
+  },
+  en: {
+    lang: 'en',
+    domain: 'https://cherryai.com',
+    title: 'Cherry Studio - The All-in-One AI Workstation',
+    ogTitle: 'Cherry Studio - The All-in-One AI Workstation | Free and Open Source',
+    shareTitle: 'Cherry Studio - All-in-One Multi-Model AI Assistant',
+    description:
+      'Cherry Studio is an open-source, free, and powerful AI desktop client. It includes AI agents, AI chat, AI image generation, knowledge base, and more, supports all major LLMs, runs on Windows/macOS/Linux, stores data locally, and is built for heavy AI users.',
+    keywords:
+      'Cherry Studio, AI assistant, AI client, LLM, ChatGPT, Claude, Gemini, DeepSeek, artificial intelligence, AI chat, AI knowledge base, AI image generation, AI translation, AI agent, macOS, Windows, Linux, open-source AI, multi-model AI, Ollama, LM Studio, local LLM',
+    ogLocale: 'en_US',
+    ogLocaleAlternate: 'zh_CN',
+    imageAlt: 'Cherry Studio - Multi-model AI assistant desktop client',
+    rssTitle: 'Cherry Studio Updates',
+    websiteAlternateName: 'Cherry Studio Official Website',
+    publisherName: 'Cherry Studio Team',
+    baiduAnalytics: false
+  }
+}
+
+const config = configs[target]
+
+if (!config) {
+  throw new Error(`Unsupported SITE_LOCALE "${target}". Expected "zh" or "en".`)
+}
+
+function replaceTagAttribute(html, tagPattern, attribute, value) {
+  return html.replace(tagPattern, (tag) => {
+    const escapedValue = value.replace(/"/g, '&quot;')
+    const attrPattern = new RegExp(`\\s${attribute}="[^"]*"`)
+
+    if (attrPattern.test(tag)) {
+      return tag.replace(attrPattern, ` ${attribute}="${escapedValue}"`)
+    }
+
+    return tag.replace(/\/?>$/, ` ${attribute}="${escapedValue}"$&`)
+  })
+}
+
+function replaceMetaContent(html, attribute, attributeValue, content) {
+  const escapedAttributeValue = attributeValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const pattern = new RegExp(`<meta\\s+${attribute}="${escapedAttributeValue}"[^>]*>`, 'g')
+  return replaceTagAttribute(html, pattern, 'content', content)
+}
+
+function replaceLinkHref(html, rel, extraSelector, href) {
+  const pattern = new RegExp(`<link\\s+rel="${rel}"${extraSelector}[^>]*>`, 'g')
+  return replaceTagAttribute(html, pattern, 'href', href)
+}
+
+function replaceJsonLd(html, type, updater) {
+  return html.replace(
+    /<script type="application\/ld\+json">\s*([\s\S]*?)\s*<\/script>/g,
+    (fullMatch, jsonText) => {
+      const data = JSON.parse(jsonText)
+
+      if (data['@type'] !== type) return fullMatch
+
+      const nextData = updater(data)
+      const nextJson = JSON.stringify(nextData, null, 2)
+
+      return `<script type="application/ld+json">\n${nextJson}\n  </script>`
+    }
+  )
+}
+
+function applyIndexTarget() {
+  const indexPath = join(distDir, 'index.html')
+  let html = readFileSync(indexPath, 'utf8')
+  const currentUrl = `${config.domain}/`
+  const socialImage = `${config.domain}/assets/images/social-card.jpg`
+
+  html = html.replace(/<html lang="[^"]*">/, `<html lang="${config.lang}">`)
+  html = html.replace(/<title>[\s\S]*?<\/title>/, `<title>${config.title}</title>`)
+  html = replaceLinkHref(html, 'canonical', '', currentUrl)
+  html = replaceLinkHref(html, 'alternate', '\\s+hreflang="zh-CN"', 'https://cherryai.com.cn/')
+  html = replaceLinkHref(html, 'alternate', '\\s+hreflang="en"', 'https://cherryai.com/')
+  html = replaceLinkHref(html, 'alternate', '\\s+hreflang="x-default"', currentUrl)
+  html = replaceMetaContent(html, 'name', 'description', config.description)
+  html = replaceMetaContent(html, 'name', 'keywords', config.keywords)
+  html = replaceMetaContent(html, 'property', 'og:url', currentUrl)
+  html = replaceMetaContent(html, 'property', 'og:title', config.ogTitle)
+  html = replaceMetaContent(html, 'property', 'og:description', config.description)
+  html = replaceMetaContent(html, 'property', 'og:image', socialImage)
+  html = replaceMetaContent(html, 'property', 'og:locale', config.ogLocale)
+  html = replaceMetaContent(html, 'property', 'og:locale:alternate', config.ogLocaleAlternate)
+  html = replaceMetaContent(html, 'property', 'og:image:alt', config.imageAlt)
+  html = replaceMetaContent(html, 'name', 'twitter:title', config.shareTitle)
+  html = replaceMetaContent(html, 'name', 'twitter:description', config.description)
+  html = replaceMetaContent(html, 'name', 'twitter:image', socialImage)
+  html = replaceMetaContent(html, 'name', 'twitter:image:alt', config.imageAlt)
+  html = replaceMetaContent(html, 'name', 'twitter:domain', config.domain.replace('https://', ''))
+  html = replaceMetaContent(html, 'itemprop', 'name', config.shareTitle)
+  html = replaceMetaContent(html, 'itemprop', 'description', config.description)
+  html = replaceMetaContent(html, 'itemprop', 'image', socialImage)
+  html = replaceMetaContent(html, 'name', 'qq:title', config.shareTitle)
+  html = replaceMetaContent(html, 'name', 'qq:description', config.description)
+  html = replaceMetaContent(html, 'name', 'qq:image', socialImage)
+  html = html.replace(
+    /<link rel="alternate" type="application\/rss\+xml" title="[^"]*" href="[^"]*" \/>/,
+    `<link rel="alternate" type="application/rss+xml" title="${config.rssTitle}" href="https://cherry-rss.ocool.online/" />`
+  )
+
+  html = replaceJsonLd(html, 'Organization', (data) => ({
+    ...data,
+    url: config.domain,
+    logo: `${config.domain}/assets/images/favicon.png`,
+    description: config.description
+  }))
+
+  html = replaceJsonLd(html, 'SoftwareApplication', (data) => ({
+    ...data,
+    description: config.description,
+    downloadUrl: `${config.domain}/download`,
+    featureList:
+      target === 'zh'
+        ? data.featureList
+        : [
+            '50+ AI providers',
+            '300+ AI models',
+            'Local LLM support with Ollama and LM Studio',
+            'AI chat, knowledge base, image generation, and translation',
+            '300+ built-in assistants',
+            'Cross-platform support for Windows, macOS, and Linux',
+            'Free and open source'
+          ]
+  }))
+
+  html = replaceJsonLd(html, 'WebSite', (data) => ({
+    ...data,
+    alternateName: config.websiteAlternateName,
+    url: config.domain,
+    description: config.description,
+    publisher: {
+      ...data.publisher,
+      name: config.publisherName
+    }
+  }))
+
+  html = html.replace(/\s*<script>\s*var _hmt[\s\S]*?hm\.src = "https:\/\/hm\.baidu\.com\/hm\.js\?449345f4fcbd338fc35a4ca7c70922d4";[\s\S]*?<\/script>/, (match) =>
+    config.baiduAnalytics ? match : ''
+  )
+
+  if (target === 'en') {
+    html = html.replace(/\s*<!--[\s\S]*?-->/g, '')
+  }
+
+  writeFileSync(indexPath, html)
+}
+
+function applyRobotsTarget() {
+  const robots = `User-agent: *\nAllow: /\n\nSitemap: ${config.domain}/sitemap.xml\n`
+  writeFileSync(join(distDir, 'robots.txt'), robots)
+}
+
+function applySitemapTarget() {
+  const siteUrls = ['/', '/download']
+  const priorities = ['1.0', '0.9']
+  const entries = siteUrls
+    .map(
+      (path, index) => `  <url>
+    <loc>${config.domain}${path === '/' ? '/' : path}</loc>
+    <priority>${priorities[index]}</priority>
+  </url>`
+    )
+    .join('\n')
+
+  const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries}
+  <url>
+    <loc>https://docs.cherry-ai.com/</loc>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://enterprise.cherryai.com.cn/</loc>
+    <priority>0.7</priority>
+  </url>
+</urlset>
+`
+
+  writeFileSync(join(distDir, 'sitemap.xml'), sitemap)
+}
+
+applyIndexTarget()
+applyRobotsTarget()
+applySitemapTarget()
+
+console.log(`Finalized ${target} static site for ${config.domain}`)

--- a/src/components/website/Footer.tsx
+++ b/src/components/website/Footer.tsx
@@ -83,11 +83,9 @@ const Footer: FC = () => {
   ]
 
   const friendlyLinks = [
-    { href: 'https://one.ocoolai.com', label: 'ocoolAI' },
     { href: 'https://poe.com/', label: 'Poe' },
     { href: 'https://suanleme.cn', label: isZhCN ? '算了么' : 'suanleme.cn' },
-    { href: 'https://gongke.net/', label: isZhCN ? '攻壳智能体' : 'gongke.net' },
-    { href: 'https://ai-bot.cn', label: isZhCN ? 'AI 工具集' : 'ai-bot.cn' }
+    { href: 'https://gongke.net/', label: isZhCN ? '攻壳智能体' : 'gongke.net' }
   ]
 
   return (
@@ -241,7 +239,7 @@ const Footer: FC = () => {
                     target="_blank"
                     rel="noopener noreferrer"
                     className="hover:text-primary">
-                    沪ICP备2021031071号-3
+                    沪ICP备2021031071号-4
                   </a>
                   <span className="mx-2">|</span>
                   <a

--- a/src/hooks/usePageMeta.ts
+++ b/src/hooks/usePageMeta.ts
@@ -1,7 +1,16 @@
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { getLanguageDomain } from '@/utils/urls'
+
 type PageType = 'home' | 'download' | 'theme' | 'careers'
+
+const CANONICAL_PATHS: Record<PageType, string> = {
+  home: '/',
+  download: '/download',
+  theme: '/theme',
+  careers: '/careers'
+}
 
 export const usePageMeta = (pageType: PageType) => {
   const { t, i18n } = useTranslation()
@@ -16,6 +25,32 @@ export const usePageMeta = (pageType: PageType) => {
     const metaDescription = document.querySelector('meta[name="description"]')
     if (metaDescription) {
       metaDescription.setAttribute('content', description)
+    }
+
+    // 更新 canonical 链接和多语言链接
+    const currentLanguage = i18n.resolvedLanguage || i18n.language
+    const canonicalOrigin = `https://${getLanguageDomain(currentLanguage)}`
+    const pagePath = CANONICAL_PATHS[pageType]
+    const canonicalUrl = `${canonicalOrigin}${pagePath}`
+
+    const canonical = document.querySelector<HTMLLinkElement>('link[rel="canonical"]')
+    if (canonical) {
+      canonical.href = canonicalUrl
+    }
+
+    const zhAlternate = document.querySelector<HTMLLinkElement>('link[rel="alternate"][hreflang="zh-CN"]')
+    if (zhAlternate) {
+      zhAlternate.href = `https://cherryai.com.cn${pagePath}`
+    }
+
+    const enAlternate = document.querySelector<HTMLLinkElement>('link[rel="alternate"][hreflang="en"]')
+    if (enAlternate) {
+      enAlternate.href = `https://cherryai.com${pagePath}`
+    }
+
+    const defaultAlternate = document.querySelector<HTMLLinkElement>('link[rel="alternate"][hreflang="x-default"]')
+    if (defaultAlternate) {
+      defaultAlternate.href = canonicalUrl
     }
 
     // 更新 Open Graph 标题

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -71,15 +71,7 @@ const getBrowserLanguage = (): SupportedLanguage | null => {
   }
 }
 
-const persistUrlLanguage = (language: SupportedLanguage | null) => {
-  if (!language) return
-
-  try {
-    window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language)
-  } catch {
-    // ignore
-  }
-
+const clearUrlLanguage = () => {
   try {
     const url = new URL(window.location.href)
     if (!url.searchParams.has(LANGUAGE_QUERY_PARAM)) return
@@ -89,6 +81,18 @@ const persistUrlLanguage = (language: SupportedLanguage | null) => {
   } catch {
     // ignore
   }
+}
+
+const persistUrlLanguage = (language: SupportedLanguage | null) => {
+  if (!language) return
+
+  try {
+    window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language)
+  } catch {
+    // ignore
+  }
+
+  clearUrlLanguage()
 }
 
 const getInitialLanguage = (
@@ -132,7 +136,7 @@ const updateHtmlLang = (language: string) => {
 }
 
 const domainDefaultLanguage = getDomainDefaultLanguage()
-const shouldRedirectLanguageDomain = isLanguageRedirectDomain()
+const shouldRedirectLanguageDomain = !domainDefaultLanguage && isLanguageRedirectDomain()
 const urlLanguage = getUrlLanguage()
 const storedLanguage = getStoredLanguage()
 const browserLanguage = getBrowserLanguage()
@@ -141,7 +145,9 @@ const preferredLanguage = urlLanguage ?? storedLanguage ?? browserLanguage
 const isRedirectingToPreferredDomain =
   shouldRedirectLanguageDomain && !!preferredLanguage && redirectToLanguageDomain(preferredLanguage, { replace: true })
 
-if (!isRedirectingToPreferredDomain) {
+if (domainDefaultLanguage) {
+  clearUrlLanguage()
+} else if (!isRedirectingToPreferredDomain) {
   persistUrlLanguage(urlLanguage)
 }
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,13 +1,7 @@
 import i18n from 'i18next'
-import LanguageDetector from 'i18next-browser-languagedetector'
 import { initReactI18next } from 'react-i18next'
 
-import {
-  getDomainDefaultLanguage,
-  isLanguageRedirectDomain,
-  LANGUAGE_QUERY_PARAM,
-  redirectToLanguageDomain
-} from '@/utils/urls'
+import { getDomainDefaultLanguage, isLanguageRedirectDomain, redirectToLanguageDomain } from '@/utils/urls'
 import en from './lang/en.json'
 import zh from './lang/zh.json'
 
@@ -24,8 +18,6 @@ const SUPPORTED_LANGUAGES = ['en-US', 'zh-CN'] as const
 
 type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number]
 
-const LANGUAGE_STORAGE_KEY = 'i18n-language'
-
 const normalizeToSupportedLanguage = (input: string | null | undefined): SupportedLanguage | null => {
   if (!input) return null
 
@@ -41,79 +33,18 @@ const normalizeToSupportedLanguage = (input: string | null | undefined): Support
   return null
 }
 
-const getUrlLanguage = (): SupportedLanguage | null => {
-  try {
-    const language = new URL(window.location.href).searchParams.get(LANGUAGE_QUERY_PARAM)
-    return normalizeToSupportedLanguage(language)
-  } catch {
-    return null
-  }
+const getEnvironmentLanguage = (): SupportedLanguage | null => {
+  return normalizeToSupportedLanguage(import.meta.env.VITE_SITE_LOCALE)
 }
 
-const getStoredLanguage = (): SupportedLanguage | null => {
-  try {
-    const stored = window.localStorage.getItem(LANGUAGE_STORAGE_KEY)
-    return normalizeToSupportedLanguage(stored)
-  } catch {
-    return null
-  }
-}
-
-const getBrowserLanguage = (): SupportedLanguage | null => {
-  try {
-    const browserLang =
-      (typeof navigator !== 'undefined' && (navigator.languages?.[0] || navigator.language)) || undefined
-
-    if (browserLang) return normalizeToSupportedLanguage(browserLang) ?? 'en-US'
-    return null
-  } catch {
-    return null
-  }
-}
-
-const clearUrlLanguage = () => {
-  try {
-    const url = new URL(window.location.href)
-    if (!url.searchParams.has(LANGUAGE_QUERY_PARAM)) return
-
-    url.searchParams.delete(LANGUAGE_QUERY_PARAM)
-    window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`)
-  } catch {
-    // ignore
-  }
-}
-
-const persistUrlLanguage = (language: SupportedLanguage | null) => {
-  if (!language) return
-
-  try {
-    window.localStorage.setItem(LANGUAGE_STORAGE_KEY, language)
-  } catch {
-    // ignore
-  }
-
-  clearUrlLanguage()
-}
-
-const getInitialLanguage = (
-  domainDefaultLanguage: SupportedLanguage | null,
-  urlLanguage: SupportedLanguage | null,
-  storedLanguage: SupportedLanguage | null,
-  browserLanguage: SupportedLanguage | null
-): SupportedLanguage => {
+const getInitialLanguage = (domainDefaultLanguage: SupportedLanguage | null): SupportedLanguage => {
   // 固定语言域名优先：cherryai.com 只显示英文，cherryai.com.cn 只显示中文
   if (domainDefaultLanguage) return domainDefaultLanguage
 
-  // 1) URL 参数：跨域语言切换落地时优先，随后会写入当前域名的 localStorage
-  if (urlLanguage) return urlLanguage
+  // 本地和非固定域名通过 VITE_SITE_LOCALE 区分语言
+  const environmentLanguage = getEnvironmentLanguage()
+  if (environmentLanguage) return environmentLanguage
 
-  // 2) localStorage：用户手动切换过则优先
-  if (storedLanguage) return storedLanguage
-
-  // 3) 浏览器语言：简体/繁体中文都设为中文，其他设为英文
-  if (browserLanguage) return browserLanguage
-
-  // 4) 都没有：默认中文
   return 'zh-CN'
 }
 
@@ -137,40 +68,21 @@ const updateHtmlLang = (language: string) => {
 
 const domainDefaultLanguage = getDomainDefaultLanguage()
 const shouldRedirectLanguageDomain = !domainDefaultLanguage && isLanguageRedirectDomain()
-const urlLanguage = getUrlLanguage()
-const storedLanguage = getStoredLanguage()
-const browserLanguage = getBrowserLanguage()
-const preferredLanguage = urlLanguage ?? storedLanguage ?? browserLanguage
+const initialLanguage = getInitialLanguage(domainDefaultLanguage)
 
-const isRedirectingToPreferredDomain =
-  shouldRedirectLanguageDomain && !!preferredLanguage && redirectToLanguageDomain(preferredLanguage, { replace: true })
-
-if (domainDefaultLanguage) {
-  clearUrlLanguage()
-} else if (!isRedirectingToPreferredDomain) {
-  persistUrlLanguage(urlLanguage)
+if (shouldRedirectLanguageDomain) {
+  redirectToLanguageDomain(initialLanguage, { replace: true })
 }
 
-const initialLanguage = getInitialLanguage(domainDefaultLanguage, urlLanguage, storedLanguage, browserLanguage)
-
-i18n
-  .use(LanguageDetector) // 仅用于缓存到 localStorage（caches），初始语言由我们控制
-  .use(initReactI18next)
-  .init({
-    resources,
-    supportedLngs: [...SUPPORTED_LANGUAGES],
-    fallbackLng: domainDefaultLanguage ?? 'zh-CN',
-    lng: initialLanguage,
-    detection: {
-      // 缓存 key 兼容旧逻辑；未来 LanguageSelector 仍会触发 detector 写入该 key
-      order: ['localStorage'],
-      caches: isRedirectingToPreferredDomain ? [] : ['localStorage'],
-      lookupLocalStorage: LANGUAGE_STORAGE_KEY
-    },
-    interpolation: {
-      escapeValue: false
-    }
-  })
+i18n.use(initReactI18next).init({
+  resources,
+  supportedLngs: [...SUPPORTED_LANGUAGES],
+  fallbackLng: domainDefaultLanguage ?? 'zh-CN',
+  lng: initialLanguage,
+  interpolation: {
+    escapeValue: false
+  }
+})
 
 // 监听语言变化，更新HTML lang属性
 i18n.on('languageChanged', () => {

--- a/src/i18n/lang/en.json
+++ b/src/i18n/lang/en.json
@@ -6,10 +6,10 @@
     "careers": "Join Cherry Studio - Careers"
   },
   "page_description": {
-    "home": "Cherry Studio AI is a powerful multi-model AI assistant supporting Windows, macOS, and Linux platforms. Quickly switch between multiple advanced LLM models to boost work and study efficiency.",
-    "download": "Download Cherry Studio AI client supporting Windows, macOS, and Linux platforms. Integrates 100+ AI models, completely free and open source.",
-    "theme": "Discover and share beautiful Cherry Studio themes to personalize your AI assistant interface. Supports both light and dark mode themes.",
-    "careers": "Join Cherry Studio core team. Looking for AI Native full-stack engineers to build next-gen AI products."
+    "home": "Cherry Studio is an open-source, free, and powerful AI desktop client. It includes AI agents, AI chat, AI image generation, knowledge base, and more, supports all major LLMs, runs on Windows/macOS/Linux, stores data locally, and is built for heavy AI users.",
+    "download": "Cherry Studio is an open-source, free, and powerful AI desktop client. It includes AI agents, AI chat, AI image generation, knowledge base, and more, supports all major LLMs, runs on Windows/macOS/Linux, stores data locally, and is built for heavy AI users.",
+    "theme": "Cherry Studio is an open-source, free, and powerful AI desktop client. It includes AI agents, AI chat, AI image generation, knowledge base, and more, supports all major LLMs, runs on Windows/macOS/Linux, stores data locally, and is built for heavy AI users.",
+    "careers": "Cherry Studio is an open-source, free, and powerful AI desktop client. It includes AI agents, AI chat, AI image generation, knowledge base, and more, supports all major LLMs, runs on Windows/macOS/Linux, stores data locally, and is built for heavy AI users."
   },
   "nav": {
     "home": "Home",

--- a/src/i18n/lang/en.json
+++ b/src/i18n/lang/en.json
@@ -7,9 +7,9 @@
   },
   "page_description": {
     "home": "Cherry Studio is an open-source, free, and powerful AI desktop client. It includes AI agents, AI chat, AI image generation, knowledge base, and more, supports all major LLMs, runs on Windows/macOS/Linux, stores data locally, and is built for heavy AI users.",
-    "download": "Cherry Studio is an open-source, free, and powerful AI desktop client. It includes AI agents, AI chat, AI image generation, knowledge base, and more, supports all major LLMs, runs on Windows/macOS/Linux, stores data locally, and is built for heavy AI users.",
-    "theme": "Cherry Studio is an open-source, free, and powerful AI desktop client. It includes AI agents, AI chat, AI image generation, knowledge base, and more, supports all major LLMs, runs on Windows/macOS/Linux, stores data locally, and is built for heavy AI users.",
-    "careers": "Cherry Studio is an open-source, free, and powerful AI desktop client. It includes AI agents, AI chat, AI image generation, knowledge base, and more, supports all major LLMs, runs on Windows/macOS/Linux, stores data locally, and is built for heavy AI users."
+    "download": "Download Cherry Studio AI client supporting Windows, macOS, and Linux platforms. Integrates 100+ AI models, completely free and open source.",
+    "theme": "Discover and share beautiful Cherry Studio themes to personalize your AI assistant interface. Supports both light and dark mode themes.",
+    "careers": "Join Cherry Studio core team. Looking for AI Native full-stack engineers to build next-gen AI products."
   },
   "nav": {
     "home": "Home",

--- a/src/i18n/lang/zh.json
+++ b/src/i18n/lang/zh.json
@@ -6,10 +6,10 @@
     "careers": "加入 Cherry Studio - 招聘"
   },
   "page_description": {
-    "home": "Cherry Studio AI 是一款强大的多模型 AI 助手，支持 Windows、macOS 和 Linux 平台。快速切换多个先进的 LLM 模型，提升工作学习效率。",
-    "download": "下载 Cherry Studio AI 客户端，支持 Windows、macOS、Linux 平台。集成 100+ AI 模型，完全免费开源。",
-    "theme": "发现和分享美丽的 Cherry Studio 主题，个性化你的 AI 助手界面。支持浅色和深色模式主题。",
-    "careers": "加入 Cherry Studio 核心团队，寻找 AI Native 全栈工程师，一起打造下一代 AI 产品。"
+    "home": "Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选",
+    "download": "Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选",
+    "theme": "Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选",
+    "careers": "Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选"
   },
   "nav": {
     "home": "主页",

--- a/src/i18n/lang/zh.json
+++ b/src/i18n/lang/zh.json
@@ -7,9 +7,9 @@
   },
   "page_description": {
     "home": "Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选",
-    "download": "Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选",
-    "theme": "Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选",
-    "careers": "Cherry Studio AI桌面客户端，开源、免费、且功能强大。AI agent、AI 对话、AI绘图、知识库等功能齐全，支持所有主流大模型，支持Windows/macOS/Linux，支持数据本地存储，是AI深度使用者的首选"
+    "download": "下载 Cherry Studio AI 客户端，支持 Windows、macOS、Linux 平台。集成 100+ AI 模型，完全免费开源。",
+    "theme": "发现和分享美丽的 Cherry Studio 主题，个性化你的 AI 助手界面。支持浅色和深色模式主题。",
+    "careers": "加入 Cherry Studio 核心团队，寻找 AI Native 全栈工程师，一起打造下一代 AI 产品。"
   },
   "nav": {
     "home": "主页",

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -80,6 +80,5 @@ export function redirectToLanguageDomain(language: string, options?: { replace?:
  */
 export function getEnterpriseUrl(language: string): string {
   language
-  return 'https://enterprise.cherry-ai.com'
-  // return language === 'en-US' ? 'https://enterprise.cherryai.com/' : 'https://enterprise.cherry-ai.com'
+  return 'https://enterprise.cherryai.com.cn'
 }

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -1,8 +1,6 @@
 const ENGLISH_DOMAIN = 'cherryai.com'
 const CHINESE_DOMAIN = 'cherryai.com.cn'
 
-export const LANGUAGE_QUERY_PARAM = 'lng'
-
 const DOMAIN_LANGUAGE_MAP: Record<string, 'en-US' | 'zh-CN'> = {
   [ENGLISH_DOMAIN]: 'en-US',
   [`www.${ENGLISH_DOMAIN}`]: 'en-US',
@@ -48,15 +46,10 @@ export function getLanguageDomain(language: string): string {
   return language.toLowerCase().startsWith('zh') ? CHINESE_DOMAIN : ENGLISH_DOMAIN
 }
 
-function getRedirectLanguage(language: string): 'en-US' | 'zh-CN' {
-  return language.toLowerCase().startsWith('zh') ? 'zh-CN' : 'en-US'
-}
-
 export function redirectToLanguageDomain(language: string, options?: { replace?: boolean }): boolean {
   if (typeof window === 'undefined') return false
 
   const hostname = getCurrentHostname()
-  const targetLanguage = getRedirectLanguage(language)
   const targetHostname = getLanguageDomain(language)
 
   if (isLocalDevelopmentHost(hostname) || hostname === targetHostname) return false
@@ -64,7 +57,6 @@ export function redirectToLanguageDomain(language: string, options?: { replace?:
   const targetUrl = new URL(window.location.href)
   targetUrl.protocol = 'https:'
   targetUrl.host = targetHostname
-  targetUrl.searchParams.set(LANGUAGE_QUERY_PARAM, targetLanguage)
 
   if (options?.replace) {
     window.location.replace(targetUrl.toString())

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,5 +1,13 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_SITE_LOCALE?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+
 interface Window {
   $: typeof import('jquery')
   marked: typeof import('marked')


### PR DESCRIPTION
Updates SEO metadata for regional deployments: Cloudflare builds English static HTML for cherryai.com, while Docker/release builds Chinese static HTML for cherryai.com.cn.
Adds robots.txt and sitemap.xml generation for the correct domain, keeps docs/enterprise links accurate, and removes selected footer friend links.
Fixes language-domain handling so fixed domains are not overridden by URL params, browser language, or local storage.
Validation: pnpm build, pnpm build:cn, targeted Biome check, node --check scripts/finalize-static-site.mjs, and xmllint on generated sitemap.