### PR TITLE
fix(seo): migrate docs links to docs.cherryai.com.cn

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -9,7 +9,7 @@
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://docs.cherry-ai.com/</loc>
+    <loc>https://docs.cherryai.com.cn/</loc>
     <priority>0.8</priority>
   </url>
   <url>

--- a/scripts/finalize-static-site.mjs
+++ b/scripts/finalize-static-site.mjs
@@ -194,7 +194,7 @@ function applySitemapTarget() {
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${entries}
   <url>
-    <loc>https://docs.cherry-ai.com/</loc>
+    <loc>https://docs.cherryai.com.cn/</loc>
     <priority>0.8</priority>
   </url>
   <url>

--- a/src/components/website/Footer.tsx
+++ b/src/components/website/Footer.tsx
@@ -78,7 +78,7 @@ const Footer: FC = () => {
   const cherryLinks = [
     { href: 'https://github.com/CherryHQ/cherry-studio', label: t('footer.cherry_studio.github') },
     { href: 'https://gitcode.com/CherryHQ/cherry-studio', label: t('footer.cherry_studio.gitcode') },
-    { href: 'https://docs.cherry-ai.com', label: t('footer.cherry_studio.docs') },
+    { href: 'https://docs.cherryai.com.cn', label: t('footer.cherry_studio.docs') },
     { href: 'https://github.com/CherryHQ/cherry-studio/issues', label: t('footer.cherry_studio.feedback') }
   ]
 
@@ -213,7 +213,7 @@ const Footer: FC = () => {
               </li>
               <li>
                 <a
-                  href="https://docs.cherry-ai.com/question-contact/suggestions"
+                  href="https://docs.cherryai.com.cn/question-contact/suggestions"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-muted-foreground hover:text-primary text-sm transition-colors duration-200">

--- a/src/components/website/MobileMenu.tsx
+++ b/src/components/website/MobileMenu.tsx
@@ -25,7 +25,7 @@ const MobileMenu: React.FC<MobileMenuProps> = ({ isOpen, onClose }) => {
     { path: '/theme', label: t('nav.theme') },
     { path: '/careers', label: t('nav.careers') },
     { path: enterpriseUrl, label: t('nav.enterprise'), external: true },
-    { path: 'https://docs.cherry-ai.com/', label: t('nav.docs'), external: true }
+    { path: 'https://docs.cherryai.com.cn/', label: t('nav.docs'), external: true }
   ]
 
   return createPortal(

--- a/src/components/website/SimpleHeader.tsx
+++ b/src/components/website/SimpleHeader.tsx
@@ -55,7 +55,7 @@ const SimpleHeader: React.FC = () => {
     { path: '/theme', label: t('nav.theme') },
     { path: '/careers', label: t('nav.careers') },
     { path: enterpriseUrl, label: t('nav.enterprise'), external: true },
-    { path: 'https://docs.cherry-ai.com/', label: t('nav.docs'), external: true }
+    { path: 'https://docs.cherryai.com.cn/', label: t('nav.docs'), external: true }
   ]
 
   return (

--- a/src/i18n/lang/en.json
+++ b/src/i18n/lang/en.json
@@ -338,7 +338,7 @@
       },
       {
         "question": "Where can I get help if I have questions?",
-        "answer": "Join our community through Telegram, Discord, or QQ groups (links on our homepage). You can also submit issues on GitHub, email support@cherry-ai.com, or check our documentation at docs.cherry-ai.com for detailed guides and tutorials."
+        "answer": "Join our community through Telegram, Discord, or QQ groups (links on our homepage). You can also submit issues on GitHub, email support@cherry-ai.com, or check our documentation at docs.cherryai.com.cn for detailed guides and tutorials."
       }
     ]
   },

--- a/src/i18n/lang/zh.json
+++ b/src/i18n/lang/zh.json
@@ -336,7 +336,7 @@
       },
       {
         "question": "遇到问题在哪里可以获得帮助？",
-        "answer": "您可以通过 Telegram、Discord 或 QQ 群加入我们的社区（链接在官网首页）。也可以在 GitHub 提交 Issue、发送邮件至 support@cherry-ai.com，或访问 docs.cherry-ai.com 查看详细的使用文档和教程。"
+        "answer": "您可以通过 Telegram、Discord 或 QQ 群加入我们的社区（链接在官网首页）。也可以在 GitHub 提交 Issue、发送邮件至 support@cherry-ai.com，或访问 docs.cherryai.com.cn 查看详细的使用文档和教程。"
       }
     ]
   },

--- a/src/pages/home/components/FeaturesSection.tsx
+++ b/src/pages/home/components/FeaturesSection.tsx
@@ -19,7 +19,7 @@ const features: Feature[] = [
     icon: MessageSquare,
     titleKey: 'features.conversation.title',
     descriptionKey: 'features.conversation.description',
-    href: 'https://docs.cherry-ai.com/cherrystudio/preview/chat',
+    href: 'https://docs.cherryai.com.cn/cherrystudio/preview/chat',
     borderColor: 'hover:border-blue-500',
     iconColor: 'text-blue-500',
     iconBg: 'bg-blue-500/10'
@@ -28,7 +28,7 @@ const features: Feature[] = [
     icon: Image,
     titleKey: 'features.drawing.title',
     descriptionKey: 'features.drawing.description',
-    href: 'https://docs.cherry-ai.com/cherrystudio/preview/drawing',
+    href: 'https://docs.cherryai.com.cn/cherrystudio/preview/drawing',
     borderColor: 'hover:border-purple-500',
     iconColor: 'text-purple-500',
     iconBg: 'bg-purple-500/10'
@@ -37,7 +37,7 @@ const features: Feature[] = [
     icon: Languages,
     titleKey: 'features.translation.title',
     descriptionKey: 'features.translation.description',
-    href: 'https://docs.cherry-ai.com/cherrystudio/preview/translation',
+    href: 'https://docs.cherryai.com.cn/cherrystudio/preview/translation',
     borderColor: 'hover:border-green-500',
     iconColor: 'text-green-500',
     iconBg: 'bg-green-500/10'
@@ -46,7 +46,7 @@ const features: Feature[] = [
     icon: Users,
     titleKey: 'features.assistants.title',
     descriptionKey: 'features.assistants.description',
-    href: 'https://docs.cherry-ai.com/cherrystudio/preview/agents',
+    href: 'https://docs.cherryai.com.cn/cherrystudio/preview/agents',
     borderColor: 'hover:border-orange-500',
     iconColor: 'text-orange-500',
     iconBg: 'bg-orange-500/10'
@@ -55,7 +55,7 @@ const features: Feature[] = [
     icon: Shield,
     titleKey: 'features.knowledge_base.title',
     descriptionKey: 'features.knowledge_base.description',
-    href: 'https://docs.cherry-ai.com/advanced-basic/knowledge-base',
+    href: 'https://docs.cherryai.com.cn/advanced-basic/knowledge-base',
     borderColor: 'hover:border-red-500',
     iconColor: 'text-red-500',
     iconBg: 'bg-red-500/10'
@@ -64,7 +64,7 @@ const features: Feature[] = [
     icon: Cloud,
     titleKey: 'features.backup.title',
     descriptionKey: 'features.backup.description',
-    href: 'https://docs.cherry-ai.com/cherrystudio/preview/settings/data',
+    href: 'https://docs.cherryai.com.cn/cherrystudio/preview/settings/data',
     borderColor: 'hover:border-indigo-500',
     iconColor: 'text-indigo-500',
     iconBg: 'bg-indigo-500/10'
@@ -89,7 +89,7 @@ const FeaturesSection: FC = () => {
             <Trans i18nKey="features.description">
               以下仅为部分功能介绍，更多功能可以下载客户端体验，或在
               <a
-                href="https://docs.cherry-ai.com"
+                href="https://docs.cherryai.com.cn"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-primary hover:underline">

--- a/src/pages/home/components/HeroSection.tsx
+++ b/src/pages/home/components/HeroSection.tsx
@@ -231,7 +231,7 @@ const HeroSection: FC = () => {
               </Link>
             </Button>
             <Button variant="outline" size="lg" asChild>
-              <a href="https://docs.cherry-ai.com" target="_blank" rel="noopener noreferrer" className="gap-2">
+              <a href="https://docs.cherryai.com.cn" target="_blank" rel="noopener noreferrer" className="gap-2">
                 {t('nav.docs')}
                 <ArrowRight className="h-4 w-4" />
               </a>


### PR DESCRIPTION
## What
Replace all 16 hardcoded `docs.cherry-ai.com` links with `docs.cherryai.com.cn` (nav header/mobile, footer, hero CTA, feature cards, zh/en i18n FAQ text, and the generated sitemap). Old domain currently only 301-redirects; new one serves 200 directly.

## Why
Issue 7 of the BING-indexing SEO audit. Serving direct 200s (not 301 chains) is cleaner for crawlers and keeps all site links on the canonical `.com.cn` domain family.

## Scope note
Issues 1-6 of the audit (canonical / hreflang / Organization+SoftwareApplication+WebSite schema / OG+Twitter / robots.txt / sitemap.xml) are **already fixed and live** via the regional static-metadata build step (#31) — verified against production. This PR only covers the remaining hardcoded docs links.

Emails (`support@cherry-ai.com`) and the `data1.cherry-ai.com` API host are intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)