### PR TITLE
feat: remove overseas AI models from website for compliance

### DIFF
--- a/src/components/website/Footer.tsx
+++ b/src/components/website/Footer.tsx
@@ -83,7 +83,6 @@ const Footer: FC = () => {
   ]
 
   const friendlyLinks = [
-    { href: 'https://poe.com/', label: 'Poe' },
     { href: 'https://suanleme.cn', label: isZhCN ? '算了么' : 'suanleme.cn' },
     { href: 'https://gongke.net/', label: isZhCN ? '攻壳智能体' : 'gongke.net' },
     { href: 'https://lizhi.shop/', label: isZhCN ? '数码荔枝正版软件' : 'DIGITALYCHEE' }

--- a/src/i18n/lang/en.json
+++ b/src/i18n/lang/en.json
@@ -270,7 +270,7 @@
     "subtitle": "Your all-in-one AI assistant platform, making AI accessible to everyone",
     "multi_model": {
       "title": "Multi-Model Freedom",
-      "description": "Support <highlight>50+ AI providers</highlight> including OpenAI, Claude, Gemini cloud models, plus local models via Ollama and LM Studio. <highlight>One client for all your AI needs</highlight>."
+      "description": "Support <highlight>50+ AI providers</highlight> including DeepSeek, Zhipu GLM, Kimi, Qwen and other leading domestic cloud models, plus local/open-source models. <highlight>One client for all your AI needs</highlight>."
     },
     "assistants": {
       "title": "300+ Smart Assistants",
@@ -310,7 +310,7 @@
     "items": [
       {
         "question": "What is Cherry Studio?",
-        "answer": "Cherry Studio is a cross-platform desktop client for AI chatbots, supporting Windows, macOS, and Linux. It integrates 300+ AI models from major providers like OpenAI, Claude, Gemini, and supports local models via Ollama and LM Studio. Beyond AI Assistants, Cherry Studio features powerful Agent capabilities - autonomous AI that can think, plan, and act. Give Agent a goal, and it will reason through problems, break them into steps, call the right tools, and execute independently while you stay in control."
+        "answer": "Cherry Studio is a cross-platform desktop client for AI chatbots, supporting Windows, macOS, and Linux. It integrates 300+ AI models from leading domestic providers like DeepSeek, Zhipu GLM, Kimi, and Qwen, and supports local/open-source models for fully offline use. Beyond AI Assistants, Cherry Studio features powerful Agent capabilities - autonomous AI that can think, plan, and act. Give Agent a goal, and it will reason through problems, break them into steps, call the right tools, and execute independently while you stay in control."
       },
       {
         "question": "Is Cherry Studio free?",
@@ -322,7 +322,7 @@
       },
       {
         "question": "Which AI models does Cherry Studio support?",
-        "answer": "Cherry Studio supports 50+ AI providers including OpenAI (GPT-4, GPT-4o), Anthropic (Claude 3.5), Google (Gemini), DeepSeek, Kimi, Qwen, and many more. It also supports local models through Ollama and LM Studio, allowing you to run AI completely offline."
+        "answer": "Cherry Studio supports 50+ AI providers including DeepSeek, Zhipu GLM, Kimi, Qwen, and many more leading domestic models. It also supports local/open-source models, allowing you to run AI completely offline."
       },
       {
         "question": "What is the Knowledge Base feature?",
@@ -348,7 +348,7 @@
   },
   "flagship_models": {
     "title": "Day-One Flagship Support",
-    "subtitle": "Latest flagship models through partners like CherryIN, OpenRouter, and SiliconFlow",
+    "subtitle": "Latest flagship models through domestic partners like CherryIN and SiliconFlow",
     "deepseek": {
       "name": "DeepSeek V4",
       "description": "DeepSeek's newest open-source flagship. A 1M-token context handles whole codebases or long documents in one shot, with coding, reasoning and long-context capabilities closing in on top closed models — strong value for heavy daily use.",
@@ -356,12 +356,12 @@
       "feature2": "Open Source",
       "feature3": "Code + Reasoning"
     },
-    "gpt": {
-      "name": "GPT-5.5",
-      "description": "OpenAI's newest flagship — sharper and more proactive than GPT-5. With 1M context and native cross-tool execution, it autonomously chains coding, research and document work into finished tasks.",
-      "feature1": "1M Context",
-      "feature2": "Autonomous Agent",
-      "feature3": "Code + Research"
+    "kimi": {
+      "name": "Kimi K3",
+      "description": "Kimi's most capable flagship yet — 2.8T parameters with native vision understanding and a 1M-token context window, built for long-horizon coding, knowledge work and deep reasoning.",
+      "feature1": "2.8T Params",
+      "feature2": "Open Source",
+      "feature3": "Coding + Vision"
     },
     "cta": "Continuously integrating future flagships…"
   },

--- a/src/i18n/lang/zh.json
+++ b/src/i18n/lang/zh.json
@@ -268,7 +268,7 @@
     "subtitle": "一站式 AI 助手平台，让 AI 触手可及",
     "multi_model": {
       "title": "多模型自由切换",
-      "description": "支持 <highlight>50+ AI 服务商</highlight>，包括 OpenAI、Claude、Gemini 等云端模型，以及 Ollama、LM Studio 等本地模型，<highlight>一个客户端满足所有需求</highlight>。"
+      "description": "支持 <highlight>50+ AI 服务商</highlight>，包括 DeepSeek、智谱 GLM、Kimi、通义千问等国产云端模型，也支持本地/开源模型，<highlight>一个客户端满足所有需求</highlight>。"
     },
     "assistants": {
       "title": "300+ 智能助手",
@@ -308,7 +308,7 @@
     "items": [
       {
         "question": "Cherry Studio 是什么？",
-        "answer": "Cherry Studio 是一款跨平台的 AI 对话客户端，支持 Windows、macOS 和 Linux。它集成了 300+ 主流 AI 模型，包括 OpenAI、Claude、Gemini 等云端模型，也支持通过 Ollama 和 LM Studio 使用本地模型。除了 AI 助手之外，Cherry Studio 还具备强大的 Agent 智能体能力——自主思考、规划和行动的 AI。给 Agent 一个目标，它会自动推理问题、拆解步骤、调用工具并独立执行，同时您始终保持控制权。"
+        "answer": "Cherry Studio 是一款跨平台的 AI 对话客户端，支持 Windows、macOS 和 Linux。它集成了 300+ 主流 AI 模型，包括 DeepSeek、智谱 GLM、Kimi、通义千问等国产云端模型，也支持本地/开源模型完全离线运行。除了 AI 助手之外，Cherry Studio 还具备强大的 Agent 智能体能力——自主思考、规划和行动的 AI。给 Agent 一个目标，它会自动推理问题、拆解步骤、调用工具并独立执行，同时您始终保持控制权。"
       },
       {
         "question": "Cherry Studio 是免费的吗？",
@@ -320,7 +320,7 @@
       },
       {
         "question": "Cherry Studio 支持哪些 AI 模型？",
-        "answer": "Cherry Studio 支持 50+ AI 服务商，包括 OpenAI (GPT-4, GPT-4o)、Anthropic (Claude 3.5)、Google (Gemini)、DeepSeek、Kimi、通义千问等众多模型。同时支持通过 Ollama 和 LM Studio 使用本地模型，实现完全离线运行。"
+        "answer": "Cherry Studio 支持 50+ AI 服务商，包括 DeepSeek、智谱 GLM、Kimi、通义千问等众多国产模型。同时支持本地/开源模型，实现完全离线运行。"
       },
       {
         "question": "知识库功能是什么？",
@@ -346,7 +346,7 @@
   },
   "flagship_models": {
     "title": "旗舰模型，首发适配",
-    "subtitle": "通过 CherryIN、OpenRouter、硅基流动 等合作伙伴，使用最新旗舰模型",
+    "subtitle": "通过 CherryIN、硅基流动 等国内合作伙伴，使用最新旗舰模型",
     "deepseek": {
       "name": "DeepSeek V4",
       "description": "DeepSeek 最新一代开源旗舰，1M 超长上下文可一次性处理整个代码库或长文档；代码、推理与长文本能力已逼近闭源顶配，是复杂任务的高性价比首选。",
@@ -354,12 +354,12 @@
       "feature2": "开源",
       "feature3": "代码 + 推理"
     },
-    "gpt": {
-      "name": "GPT-5.5",
-      "description": "OpenAI 最新一代旗舰，比上代更聪明、更主动；1M 上下文配合原生跨工具调用，自主串起代码、研究与文档处理，把复杂任务一气呵成。",
-      "feature1": "1M 上下文",
-      "feature2": "自主 Agent",
-      "feature3": "代码 + 研究"
+    "kimi": {
+      "name": "Kimi K3",
+      "description": "Kimi 迄今能力最强的旗舰模型，2.8 万亿参数，原生支持视觉理解与 1M 超长上下文；面向长程编程、知识工作与深度推理，为复杂任务而生。",
+      "feature1": "2.8T 参数",
+      "feature2": "开源",
+      "feature3": "长程编程 + 视觉"
     },
     "cta": "持续接入未来新模型…"
   },

--- a/src/pages/home/components/FlagshipModelsSection.tsx
+++ b/src/pages/home/components/FlagshipModelsSection.tsx
@@ -33,10 +33,10 @@ const flagshipModels: FlagshipModel[] = [
     iconBg: 'bg-amber-500/10'
   },
   {
-    nameKey: 'flagship_models.gpt.name',
-    descriptionKey: 'flagship_models.gpt.description',
-    href: 'https://openai.com/index/introducing-gpt-5-5/',
-    features: ['flagship_models.gpt.feature1', 'flagship_models.gpt.feature2', 'flagship_models.gpt.feature3'],
+    nameKey: 'flagship_models.kimi.name',
+    descriptionKey: 'flagship_models.kimi.description',
+    href: 'https://platform.kimi.com/docs/guide/kimi-k3-quickstart',
+    features: ['flagship_models.kimi.feature1', 'flagship_models.kimi.feature2', 'flagship_models.kimi.feature3'],
     icon: Sparkles,
     iconColor: 'text-purple-500',
     iconBg: 'bg-purple-500/10'

--- a/src/pages/home/components/ProvidersSection.tsx
+++ b/src/pages/home/components/ProvidersSection.tsx
@@ -3,25 +3,21 @@ import { useTranslation } from 'react-i18next'
 
 // Import logos
 import ai302Logo from '@/assets/images/provider_logo/302ai.svg'
-import anthropicLogo from '@/assets/images/provider_logo/anthropic.svg'
-import azureLogo from '@/assets/images/provider_logo/azure-color.svg'
+import ai360Logo from '@/assets/images/provider_logo/ai360-color.svg'
 import baichuanLogo from '@/assets/images/provider_logo/baichuan-color.svg'
+import baiducloudLogo from '@/assets/images/provider_logo/baiducloud-color.svg'
 import bytedanceLogo from '@/assets/images/provider_logo/bytedance-color.svg'
 import deepseekLogo from '@/assets/images/provider_logo/deepseek-color.svg'
-import googleLogo from '@/assets/images/provider_logo/google-color.svg'
-import groqLogo from '@/assets/images/provider_logo/groq.svg'
-import huggingfaceLogo from '@/assets/images/provider_logo/huggingface-color.svg'
-import metaLogo from '@/assets/images/provider_logo/meta-color.svg'
+import giteeAiLogo from '@/assets/images/provider_logo/gitee-ai.svg'
+import hunyuanLogo from '@/assets/images/provider_logo/hunyuan-color.svg'
 import minimaxLogo from '@/assets/images/provider_logo/minimax-color.svg'
-import mistralLogo from '@/assets/images/provider_logo/mistral-color.svg'
+import modelscopeLogo from '@/assets/images/provider_logo/modelscope.webp'
 import moonshotLogo from '@/assets/images/provider_logo/moonshot.svg'
-import ollamaLogo from '@/assets/images/provider_logo/ollama.svg'
-import openaiLogo from '@/assets/images/provider_logo/openai.svg'
-import openrouterLogo from '@/assets/images/provider_logo/openrouter.svg'
 import qwenLogo from '@/assets/images/provider_logo/qwen-color.svg'
 import siliconcloudLogo from '@/assets/images/provider_logo/siliconcloud-color.svg'
+import sparkLogo from '@/assets/images/provider_logo/spark-color.svg'
 import stepfunLogo from '@/assets/images/provider_logo/stepfun-color.svg'
-import xaiLogo from '@/assets/images/provider_logo/xai.svg'
+import zerooneLogo from '@/assets/images/provider_logo/zeroone.svg'
 import zhipuLogo from '@/assets/images/provider_logo/zhipu-color.svg'
 
 interface LogoInfo {
@@ -30,33 +26,29 @@ interface LogoInfo {
   darkInvert?: boolean
 }
 
-// 内环 logos (6个) - 最知名的顶级服务商
+// 内环 logos (6个) - 最知名的顶级国产服务商
 const innerLogos: LogoInfo[] = [
-  { src: openaiLogo, name: 'OpenAI', darkInvert: true },
-  { src: anthropicLogo, name: 'Anthropic', darkInvert: true },
-  { src: googleLogo, name: 'Google' },
-  { src: xaiLogo, name: 'xAI', darkInvert: true },
-  { src: metaLogo, name: 'Meta' },
-  { src: deepseekLogo, name: 'DeepSeek' }
+  { src: deepseekLogo, name: 'DeepSeek', darkInvert: false },
+  { src: zhipuLogo, name: 'Zhipu AI / GLM', darkInvert: false },
+  { src: qwenLogo, name: 'Qwen', darkInvert: false },
+  { src: moonshotLogo, name: 'Moonshot AI', darkInvert: true },
+  { src: baiducloudLogo, name: 'Baidu AI Cloud', darkInvert: false },
+  { src: bytedanceLogo, name: 'ByteDance Doubao', darkInvert: false }
 ]
 
-// 外环 logos - 其他知名服务商
+// 外环 logos - 其他国产服务商
 const outerLogos: LogoInfo[] = [
-  { src: mistralLogo, name: 'Mistral' },
-  { src: azureLogo, name: 'Azure' },
-  { src: qwenLogo, name: 'Qwen' },
-  { src: ollamaLogo, name: 'Ollama', darkInvert: true },
-  { src: groqLogo, name: 'Groq', darkInvert: true },
-  { src: huggingfaceLogo, name: 'Hugging Face' },
-  { src: openrouterLogo, name: 'OpenRouter', darkInvert: true },
-  { src: zhipuLogo, name: 'Zhipu AI' },
-  { src: ai302Logo, name: '302.AI' },
-  { src: bytedanceLogo, name: 'ByteDance' },
-  { src: moonshotLogo, name: 'Moonshot', darkInvert: true },
-  { src: baichuanLogo, name: 'Baichuan' },
-  { src: minimaxLogo, name: 'MiniMax' },
-  { src: siliconcloudLogo, name: 'SiliconCloud' },
-  { src: stepfunLogo, name: 'StepFun' }
+  { src: hunyuanLogo, name: 'Tencent Hunyuan', darkInvert: false },
+  { src: baichuanLogo, name: 'Baichuan AI', darkInvert: false },
+  { src: minimaxLogo, name: 'MiniMax', darkInvert: false },
+  { src: stepfunLogo, name: 'StepFun', darkInvert: false },
+  { src: sparkLogo, name: 'iFlytek Spark', darkInvert: false },
+  { src: siliconcloudLogo, name: 'SiliconFlow', darkInvert: false },
+  { src: ai360Logo, name: '360 AI', darkInvert: false },
+  { src: zerooneLogo, name: '01.AI', darkInvert: true },
+  { src: giteeAiLogo, name: 'Gitee AI', darkInvert: true },
+  { src: ai302Logo, name: '302.AI', darkInvert: false },
+  { src: modelscopeLogo, name: 'ModelScope', darkInvert: false }
 ]
 
 const ProvidersSection: FC = () => {


### PR DESCRIPTION
## 背景

因合规要求，需要去掉官网首页展示的海外模型（OpenAI/Claude/GPT/Gemini 等）。

## 改动内容

1. **旗舰模型卡**：GPT-5.5 → Kimi K3（国产旗舰），链接指向 `platform.kimi.com`
2. **服务商轨道 logo**：移除 OpenAI/Anthropic/Google/xAI/Meta 等海外 logo，替换为 DeepSeek、智谱 GLM、Qwen、Moonshot、百度、字节等国产服务商
3. **i18n 文案（zh/en）**：首页高亮区块 + FAQ 中的 OpenAI/Claude/Gemini 等表述，替换为 DeepSeek、智谱 GLM、Kimi、通义千问等国产模型
4. **Footer**：移除 Poe 友情链接

## 说明

- 基于上游最新 main 应用增量补丁，未覆盖上游其他改动
- 截图资源（产品界面截图）未在本次改动范围，后续单独处理

Co-Authored-By: Claude <noreply@anthropic.com>